### PR TITLE
Refactor/132 home

### DIFF
--- a/Harumeonglog.xcodeproj/project.pbxproj
+++ b/Harumeonglog.xcodeproj/project.pbxproj
@@ -188,7 +188,8 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Harumeonglog/Harumeonglog.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2QJX795Q3R;
@@ -213,7 +214,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.iseungjun.Harumeonglog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Haru25/07/13;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = HAru/25/09/02;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -231,7 +232,8 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Harumeonglog/Harumeonglog.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2QJX795Q3R;
@@ -256,7 +258,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.iseungjun.Harumeonglog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Haru25/07/13;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = HAru/25/09/02;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Harumeonglog/Event/Controllers/AddEventViewController.swift
+++ b/Harumeonglog/Event/Controllers/AddEventViewController.swift
@@ -23,6 +23,7 @@ class AddEventViewController: UIViewController {
     weak var delegate: AddEventViewControllerDelegate?
     
     private var selectedCategory: CategoryType? // 선택된 카테고리 저장
+    private var isSaving: Bool = false
     
     private lazy var addEventView: AddEventView = {
         let view = AddEventView()
@@ -82,6 +83,10 @@ class AddEventViewController: UIViewController {
     //저장버튼 동작 함수
     @objc
     private func saveButtonTapped(){
+        // Prevent duplicate taps
+        if isSaving { return }
+        isSaving = true
+        addEventView.navigationBar.rightButton.isEnabled = false
         guard let accessToken = KeychainService.get(key: K.Keys.accessToken),
               let selectedCategory = addEventView.selectedCategory else { return }
         
@@ -299,6 +304,8 @@ extension AddEventViewController {
             case .success(let response):
                 print("일정 추가 성공 !!: \(response)")
                 DispatchQueue.main.async {
+                    self.isSaving = false
+                    self.addEventView.navigationBar.rightButton.isEnabled = true
                     self.navigationController?.popViewController(animated: true)
                     self.delegate?.didAddEvent() // 델리게이트 호출
                 }
@@ -317,6 +324,10 @@ extension AddEventViewController {
                     print("서버 응답 JSON 본문:\n\(json)")
                 } else {
                     print("응답 데이터 없음")
+                }
+                DispatchQueue.main.async {
+                    self.isSaving = false
+                    self.addEventView.navigationBar.rightButton.isEnabled = true
                 }
             }
         }

--- a/Harumeonglog/Event/Controllers/EventViewController/EventVC +UITable.swift
+++ b/Harumeonglog/Event/Controllers/EventViewController/EventVC +UITable.swift
@@ -11,17 +11,25 @@ extension EventView {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if filteredEvents.isEmpty {
             let emptyLabel = UILabel()
+            emptyLabel.translatesAutoresizingMaskIntoConstraints = false
             emptyLabel.text = "일정이 아직 없어요.\n오른쪽 하단 + 버튼을 눌러 새 일정을 추가해보세요!"
             emptyLabel.textColor = .gray03
             emptyLabel.font = .body
             emptyLabel.textAlignment = .center
-            emptyLabel.numberOfLines = 2
-            emptyLabel.sizeToFit()
+            emptyLabel.numberOfLines = 0
             
-            let yOffset = -50 
             let containerView = UIView(frame: tableView.bounds)
-            emptyLabel.center = CGPoint(x: containerView.center.x, y: containerView.center.y + CGFloat(yOffset))
+            containerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             containerView.addSubview(emptyLabel)
+            
+            // Center with slight downward offset to avoid category overlap
+            NSLayoutConstraint.activate([
+                emptyLabel.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+                // Slightly raised so it doesn't collide with the + button, but still visible when calendar collapses
+                emptyLabel.centerYAnchor.constraint(equalTo: containerView.centerYAnchor, constant: -20),
+                emptyLabel.leadingAnchor.constraint(greaterThanOrEqualTo: containerView.leadingAnchor, constant: 24),
+                emptyLabel.trailingAnchor.constraint(lessThanOrEqualTo: containerView.trailingAnchor, constant: -24)
+            ])
             
             tableView.backgroundView = containerView
         } else {

--- a/Harumeonglog/Event/Views/AddEventView.swift
+++ b/Harumeonglog/Event/Views/AddEventView.swift
@@ -146,7 +146,7 @@ class AddEventView: UIView, UITableViewDelegate, UITableViewDataSource {
 
         // 아이콘 위치 설정 (버튼의 오른쪽 끝에서 25px 떨어지도록 고정)
         NSLayoutConstraint.activate([
-            iconImageView.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -25),
+            iconImageView.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -20),
             iconImageView.centerYAnchor.constraint(equalTo: button.centerYAnchor),
             iconImageView.widthAnchor.constraint(equalToConstant: 18),
             iconImageView.heightAnchor.constraint(equalToConstant: 18)
@@ -252,23 +252,23 @@ class AddEventView: UIView, UITableViewDelegate, UITableViewDataSource {
         }
         
         timeIcon.snp.makeConstraints { make in
-            make.leading.equalTo(EventInfoView.snp.leading).offset(30)  // EventInfoView의 leading에서 30pt
-            make.top.equalToSuperview().offset(20)  // 상단에서 20pt
+            make.leading.equalTo(EventInfoView.snp.leading).offset(20)
+            make.top.equalToSuperview().offset(20)
         }
             
         repeatIcon.snp.makeConstraints { make in
-            make.leading.equalTo(EventInfoView.snp.leading).offset(30)
-            make.top.equalTo(timeIcon.snp.bottom).offset(28)  // 요소 간 간격 40pt
+            make.leading.equalTo(EventInfoView.snp.leading).offset(20)
+            make.top.equalTo(timeIcon.snp.bottom).offset(28)
         }
             
             //버튼 크기 및 위치 설정
         dateButton.snp.makeConstraints { make in
-            make.leading.equalTo(timeIcon.snp.trailing).offset(15)
+            make.leading.equalTo(timeIcon.snp.trailing).offset(12)
             make.centerY.equalTo(timeIcon)
         }
         
         timeButton.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().inset(25)
+            make.trailing.equalToSuperview().inset(20)
             make.centerY.equalTo(timeIcon)
         }
             
@@ -279,7 +279,7 @@ class AddEventView: UIView, UITableViewDelegate, UITableViewDataSource {
                 if let prev = previousButton {
                     make.leading.equalTo(prev.snp.trailing).offset(10) // 각 버튼 사이 8pt 간격
                 } else {
-                    make.leading.equalTo(repeatIcon.snp.trailing).offset(15) // 첫 번째 버튼은 repeatIcon에서 15pt 떨어짐
+                    make.leading.equalTo(repeatIcon.snp.trailing).offset(12) // 첫 번째 버튼은 repeatIcon에서 12pt
                 }
                 make.centerY.equalTo(repeatIcon.snp.centerY)
                 make.width.height.equalTo(30) // 모든 버튼 크기 동일
@@ -290,34 +290,30 @@ class AddEventView: UIView, UITableViewDelegate, UITableViewDataSource {
         titleTextField.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(20)
             make.height.equalTo(45)
-            make.leading.equalToSuperview().offset(20)
-            make.trailing.equalToSuperview().inset(20)
+            make.leading.trailing.equalToSuperview().inset(20)
             make.centerX.equalToSuperview()
         }
         
         EventInfoView.snp.makeConstraints { make in
             make.top.equalTo(titleTextField.snp.bottom).offset(15)
-            make.leading.equalToSuperview().offset(20)
-            make.trailing.equalToSuperview().inset(20)
-            make.height.equalTo(120) // 높이 줄임
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(120)
             make.centerX.equalToSuperview()
         }
         
         categoryButton.snp.makeConstraints { make in
             make.top.equalTo(EventInfoView.snp.bottom).offset(15)
             make.height.equalTo(45)
-            make.leading.equalToSuperview().offset(20)
-            make.trailing.equalToSuperview().inset(20)
+            make.leading.trailing.equalToSuperview().inset(20)
             make.centerX.equalToSuperview()
         }
         
         dropdownTableView.snp.makeConstraints { make in
             make.top.equalTo(categoryButton.snp.bottom).offset(5)
-            make.leading.equalToSuperview().offset(20)
-            make.trailing.equalToSuperview().inset(20)
+            make.leading.trailing.equalToSuperview().inset(20)
             make.height.equalTo(200)
             make.centerX.equalToSuperview()
-            make.bottom.equalToSuperview().inset(20) // 콘텐츠 뷰의 하단에 고정
+            make.bottom.equalToSuperview().inset(20)
         }
         
         // 삭제 버튼을 화면 하단에 고정

--- a/Harumeonglog/Extensions/Set+Weekdays.swift
+++ b/Harumeonglog/Extensions/Set+Weekdays.swift
@@ -23,3 +23,26 @@ extension Set where Element == String {
         return self.compactMap{(weekdayMap[$0])}
     }
 }
+
+public extension Sequence where Element == String {
+    func mappedToKoreanWeekdays() -> Set<String> {
+        let englishToKorean: [String: String] = [
+            "MON": "월", "TUE": "화", "WED": "수", "THU": "목",
+            "FRI": "금", "SAT": "토", "SUN": "일",
+            "MONDAY": "월", "TUESDAY": "화", "WEDNESDAY": "수", "THURSDAY": "목",
+            "FRIDAY": "금", "SATURDAY": "토", "SUNDAY": "일"
+        ]
+        let koreanSet: Set<String> = ["월","화","수","목","금","토","일"]
+        var result = Set<String>()
+        for raw in self {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            let upper = trimmed.uppercased()
+            if let mapped = englishToKorean[upper] {
+                result.insert(mapped)
+            } else if koreanSet.contains(trimmed) {
+                result.insert(trimmed)
+            }
+        }
+        return result
+    }
+}

--- a/Harumeonglog/Home/Controllers/HomeViewController/HomeVC+Profile.swift
+++ b/Harumeonglog/Home/Controllers/HomeViewController/HomeVC+Profile.swift
@@ -166,6 +166,8 @@ extension HomeViewController: ProfileSelectDelegate {
     }
     
     @objc func profileImageTapped() {
+        // Prevent duplicate presentation
+        if self.presentedViewController is ProfileSelectModalViewController { return }
         let profileModalVC = ProfileSelectModalViewController()
         profileModalVC.modalPresentationStyle = .pageSheet
         profileModalVC.delegate = self

--- a/Harumeonglog/Home/Controllers/HomeViewController/HomeViewController.swift
+++ b/Harumeonglog/Home/Controllers/HomeViewController/HomeViewController.swift
@@ -43,10 +43,10 @@ class HomeViewController: UIViewController, HomeViewDelegate {
         homeView.calendarView.delegate = self
         homeView.calendarView.dataSource = self
         homeView.eventView.delegate = self
-
+        
         homeView.calendarView.setCurrentPage(Date(), animated: false)
         homeView.calendarView.select(Date())
-
+        
         fetchActivePets()
         
         setupButtons()
@@ -54,6 +54,9 @@ class HomeViewController: UIViewController, HomeViewDelegate {
         
         // 키보드 숨김 처리 추가
         hideKeyboardWhenTappedAround()
+        // Enable interactive pop gesture globally for this nav stack
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
     }
 
     override func viewDidLayoutSubviews() {
@@ -147,6 +150,8 @@ class HomeViewController: UIViewController, HomeViewDelegate {
     }
 
     @objc func addeventButtonTapped() {
+        // Prevent duplicate pushes
+        if let top = self.navigationController?.topViewController, top is AddEventViewController { return }
         let addVC = AddEventViewController()
         addVC.selectedDate = selectedDate // 선택된 날짜 전달
         addVC.delegate = self // 델리게이트 설정
@@ -357,7 +362,7 @@ extension HomeViewController: AddEventViewControllerDelegate {
 
 
 // MARK: - UICollectionViewDelegate
-extension HomeViewController: UICollectionViewDelegate {
+extension HomeViewController: UICollectionViewDelegate, UIGestureRecognizerDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         // 이벤트 목록 중 선택된 index의 eventId를 전달
         let editVC = EditEventViewController(eventId: indexPath.row + 1)

--- a/Harumeonglog/Home/Controllers/ProfileSelectModalViewController.swift
+++ b/Harumeonglog/Home/Controllers/ProfileSelectModalViewController.swift
@@ -187,3 +187,15 @@ extension ProfileSelectModalViewController: UICollectionViewDelegate, UICollecti
         self.dismiss(animated: true, completion: nil)
     }
 }
+
+// Separate flow layout sizing extension
+extension ProfileSelectModalViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let columns: CGFloat = 2
+        let horizontalInset: CGFloat = 20 * 2
+        let interItemSpacing: CGFloat = 12
+        let totalSpacing = horizontalInset + (columns - 1) * interItemSpacing
+        let width = floor((collectionView.bounds.width - totalSpacing) / columns)
+        return CGSize(width: width, height: 120)
+    }
+}

--- a/Harumeonglog/Home/Models/ProfileSelectCollectionViewCell.swift
+++ b/Harumeonglog/Home/Models/ProfileSelectCollectionViewCell.swift
@@ -23,7 +23,9 @@ class ProfileSelectCollectionViewCell: UICollectionViewCell {
         label.textColor = .gray00
         label.numberOfLines = 1
         label.textAlignment = .center
-        label.lineBreakMode = .byWordWrapping
+        label.lineBreakMode = .byTruncatingTail 
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.8
         return label
     }()
     
@@ -75,7 +77,8 @@ class ProfileSelectCollectionViewCell: UICollectionViewCell {
         profileNameLabel.snp.makeConstraints { make in
             make.height.equalTo(20)
             make.bottom.equalToSuperview()
-            make.centerX.equalToSuperview()
+            make.leading.equalToSuperview().offset(2)
+            make.trailing.equalToSuperview().inset(2)
         }
         
         checkmarkImageView.snp.makeConstraints { make in

--- a/Harumeonglog/Home/Views/HomeView.swift
+++ b/Harumeonglog/Home/Views/HomeView.swift
@@ -196,20 +196,21 @@ class HomeView: UIView, FSCalendarDelegate, FSCalendarDataSource {
         addSubview(eventView)
         addSubview(addeventButton)
         alarmButton.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(100)
-            make.trailing.equalToSuperview().inset(30)
+            make.top.equalTo(self.safeAreaLayoutGuide).offset(16)
+            make.trailing.equalToSuperview().inset(20)
             make.width.height.equalTo(30)
         }
         
         profileButton.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(90)
-            make.leading.equalToSuperview().offset(30)
+            make.top.equalTo(self.safeAreaLayoutGuide).offset(16)
+            make.leading.equalToSuperview().offset(20)
             make.width.height.equalTo(70)
         }
         
         nicknameLabel.snp.makeConstraints { make in
             make.top.equalTo(profileButton.snp.top).offset(18)
-            make.leading.equalTo(profileButton.snp.trailing).offset(18)
+            make.leading.equalTo(profileButton.snp.trailing).offset(12)
+            make.trailing.lessThanOrEqualToSuperview().inset(20)
             make.height.greaterThanOrEqualTo(20)
         }
         
@@ -232,8 +233,8 @@ class HomeView: UIView, FSCalendarDelegate, FSCalendarDataSource {
         }
         
         calendarView.snp.makeConstraints { make in
-            make.top.equalTo(profileButton.snp.bottom).offset(3)
-            make.leading.trailing.equalToSuperview().inset(15)
+            make.top.equalTo(profileButton.snp.bottom).offset(12)
+            make.leading.trailing.equalToSuperview().inset(20)
             calendarHeightConstraint = make.height.equalTo(370).constraint
         }
         
@@ -250,7 +251,7 @@ class HomeView: UIView, FSCalendarDelegate, FSCalendarDataSource {
         }
         
         headerStackView.snp.makeConstraints { make in
-            make.leading.equalTo(calendarView.snp.leading).offset(15) //왼쪽 정렬
+            make.leading.equalTo(calendarView.snp.leading)
             make.top.equalTo(profileButton.snp.bottom).offset(20)
         }
         

--- a/Harumeonglog/Home/Views/ProfileSelectModalView.swift
+++ b/Harumeonglog/Home/Views/ProfileSelectModalView.swift
@@ -12,12 +12,28 @@ class ProfileSelectModalView: UIView {
     
     var delegate: ProfileSelectDelegate?
     
+    // Optional: name text field with length limit to prevent overflow
+    let nameTextField: LimitedLengthTextField = {
+        let tf = LimitedLengthTextField()
+        tf.maxLength = 12
+        tf.font = .body
+        tf.textColor = .gray00
+        tf.textAlignment = .center
+        tf.backgroundColor = .white
+        tf.layer.borderWidth = 1
+        tf.layer.borderColor = UIColor.brown02.cgColor
+        tf.layer.cornerRadius = 12
+        tf.isHidden = true // shown if needed
+        return tf
+    }()
+    
     lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         layout.minimumInteritemSpacing = 50 //옆 간격
         layout.minimumLineSpacing = 40 //위아래 간격
         layout.itemSize = CGSize(width: 70, height: 110) //cell size
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .white
@@ -46,11 +62,18 @@ class ProfileSelectModalView: UIView {
     
     private func addComponents() {
         addSubview(collectionView)
+        addSubview(nameTextField)
         
         collectionView.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(60)
-            make.leading.trailing.equalToSuperview().inset(100) // 좌우 여백 설정
+            make.leading.trailing.equalToSuperview().inset(20)
             make.bottom.equalToSuperview().inset(30)
+        }
+        
+        nameTextField.snp.makeConstraints { make in
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.bottom.equalTo(self.safeAreaLayoutGuide).inset(16)
+            make.height.equalTo(40)
         }
     }
 }

--- a/Harumeonglog/Home/Views/ProfileSelectModalView.swift
+++ b/Harumeonglog/Home/Views/ProfileSelectModalView.swift
@@ -30,8 +30,8 @@ class ProfileSelectModalView: UIView {
     lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
-        layout.minimumInteritemSpacing = 50 //옆 간격
-        layout.minimumLineSpacing = 40 //위아래 간격
+        layout.minimumInteritemSpacing = 12 //옆 간격 (2열)
+        layout.minimumLineSpacing = 20 //위아래 간격
         layout.itemSize = CGSize(width: 70, height: 110) //cell size
         layout.sectionInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
         

--- a/Harumeonglog/Info.plist
+++ b/Harumeonglog/Info.plist
@@ -52,5 +52,9 @@
 	<array>
 		<string>remote-notification</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>사진을 저장하기 위해 사진 라이브러리 접근이 필요합니다.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>사진을 앨범에 저장하기 위해 권한이 필요합니다.</string>
 </dict>
 </plist>

--- a/Harumeonglog/Login/LoginView.swift
+++ b/Harumeonglog/Login/LoginView.swift
@@ -14,7 +14,7 @@ class LoginView: UIView {
     private lazy var appLogo = UIImageView().then {
         $0.contentMode = .scaleAspectFit
         $0.backgroundColor = .white
-        $0.image = .appLogo 
+        $0.image = .appLogo
     }
     
     public lazy var kakaoLoginButton = SocialLoginButton()

--- a/Harumeonglog/Photos/Models/AlbumCell.swift
+++ b/Harumeonglog/Photos/Models/AlbumCell.swift
@@ -38,7 +38,7 @@ class AlbumCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         addComponents()
-        contentView.layer.cornerRadius = 20
+        contentView.layer.cornerRadius = 12
         contentView.layer.masksToBounds = true
         contentView.backgroundColor = .white
     }

--- a/Harumeonglog/Photos/Models/PictureCell.swift
+++ b/Harumeonglog/Photos/Models/PictureCell.swift
@@ -19,6 +19,8 @@ class PictureCell: UICollectionViewCell {
     var overlayView: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor.black.withAlphaComponent(0.2)
+        view.layer.cornerRadius = 12
+        view.layer.masksToBounds = true
         view.isHidden = true
         return view
     }()
@@ -39,6 +41,8 @@ class PictureCell: UICollectionViewCell {
         contentView.addSubview(imageView)
         contentView.addSubview(overlayView)
         contentView.addSubview(addButton)
+        contentView.layer.cornerRadius = 12
+        contentView.layer.masksToBounds = true
 
         imageView.snp.makeConstraints { make in
             make.top.leading.trailing.bottom.equalToSuperview()
@@ -76,13 +80,15 @@ class PictureCell: UICollectionViewCell {
     }
 
     func setSelectedBorder(_ isSelected: Bool) {
+        contentView.layer.cornerRadius = 12
+        contentView.layer.masksToBounds = true
         if isSelected {
-            self.layer.borderWidth = 3
-            self.layer.borderColor = UIColor.blue01.cgColor
+            contentView.layer.borderWidth = 3
+            contentView.layer.borderColor = UIColor.blue01.cgColor
             overlayView.isHidden = false
         } else {
-            self.layer.borderWidth = 0
-            self.layer.borderColor = nil
+            contentView.layer.borderWidth = 0
+            contentView.layer.borderColor = nil
             overlayView.isHidden = true
         }
     }

--- a/Harumeonglog/Photos/Views/PhotoAlbumsView.swift
+++ b/Harumeonglog/Photos/Views/PhotoAlbumsView.swift
@@ -25,7 +25,6 @@ class PhotoAlbumsView: UIView {
     lazy var albumCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
-        layout.itemSize = CGSize(width: 362, height: 90)
         layout.minimumLineSpacing = 13
         layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)

--- a/Harumeonglog/Photos/Views/PhotoDetailView.swift
+++ b/Harumeonglog/Photos/Views/PhotoDetailView.swift
@@ -57,11 +57,13 @@ class PhotoDetailView: UIView {
         bottomActionBar.addSubview(downloadButton)
         bottomActionBar.addSubview(deleteButton)
         
+        let aspect = max(imageView.image?.size.height ?? 1, 1) / max(imageView.image?.size.width ?? 1, 1)
         imageView.snp.makeConstraints { make in
-            make.centerX.equalToSuperview()
+            make.leading.trailing.equalToSuperview().inset(20)
             make.centerY.equalToSuperview()
-            make.width.equalToSuperview().multipliedBy(0.9)
-            make.height.equalTo(imageView.snp.width)
+            make.top.greaterThanOrEqualTo(navigationBar.snp.bottom).offset(16)
+            make.bottom.lessThanOrEqualTo(bottomActionBar.snp.top).offset(-16)
+            make.height.equalTo(imageView.snp.width).multipliedBy(aspect)
         }
         
         navigationBar.snp.makeConstraints { make in

--- a/Harumeonglog/Photos/Views/PhotosView.swift
+++ b/Harumeonglog/Photos/Views/PhotosView.swift
@@ -15,8 +15,8 @@ class PhotosView: UIView {
     lazy var PhotosCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
-        layout.itemSize = CGSize(width: 120, height: 120) 
         layout.minimumInteritemSpacing = 8
+        layout.minimumLineSpacing = 8
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.showsVerticalScrollIndicator = false

--- a/Harumeonglog/Photos/controllers/PhotoAlbumsViewController.swift
+++ b/Harumeonglog/Photos/controllers/PhotoAlbumsViewController.swift
@@ -17,6 +17,7 @@ class PhotoAlbumsViewController: UIViewController {
     }()
     
     private var isLoading = false
+    private var isOpeningAlbum = false
     
     // 앨범의 사진 개수를 캐싱하는 딕셔너리
     private var photoCountCache: [Int: Int] = [:]
@@ -211,8 +212,20 @@ extension PhotoAlbumsViewController: UICollectionViewDelegate, UICollectionViewD
         return cell
     }
     
+    // Dynamic full-width cell sizing
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let width = collectionView.bounds.width
+        return CGSize(width: width, height: 90)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 13
+    }
+    
     //셀 선택했을때 해당 앨범으로 이동
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if isOpeningAlbum { return }
+        isOpeningAlbum = true
         let album = photoAlbumsView.albums[indexPath.item]
         let petId = album.petId
         
@@ -267,15 +280,19 @@ extension PhotoAlbumsViewController: UICollectionViewDelegate, UICollectionViewD
 
                         let photosVC = PhotosViewController(album: updatedAlbum)
                         self?.navigationController?.pushViewController(photosVC, animated: true)
+                        self?.isOpeningAlbum = false
                     }
 
                 case .message(let msg):
                     print("이미지 조회 실패 메시지: \(msg)")
+                    self?.isOpeningAlbum = false
                 case .none:
                     print("이미지 응답 result 값이 없습니다.")
+                    self?.isOpeningAlbum = false
                 }
             case .failure(let error):
                 print("이미지 목록 불러오기 실패:", error)
+                self?.isOpeningAlbum = false
             }
         }
     }


### PR DESCRIPTION
- [x]  일정 삭제 버튼 볼드체로
- [x]  아이폰 크기 작아지면 사진첩 가운데가 뻥 뚫려버림 (가로에 3개씩인데 두개씩밖에 크기가 안되서 그런듯?)
- [x]  사진첩 사진들 네모 cornerradius 수정
- [x]  pet select modal 창 이미지 캐싱
- [x]  홈화면이랑 사진첩 화면에서 뒤로가기 할때 슬라이드해도 뒤로가기 되도록 활성화
- [x]  사진 다운로드 버튼 활성화
- [x]  “일정이 아직 없어요. 오른쪽 하단 + 버튼을 눌러 새 일정을 추가해보세요!” → 카테고리에 가려져서 안보임, 위치 조정
- [x]  사진 넣을때 사이즈가 1:1이나 16:9인가로 고정되어있음. 카메라로 찍으면 찍은 사이즈 그대로 넣어지게. 이건 해결됐는데 단일 사진 뷰 보일때 너무 작게 나옴. 옆 여백 일정해야함.
- [x]  pet select modal 창 textfield 글자 수 제한 → 강아지 이름 길면 깨짐
- [x]  느려서 여러번 누르면 여러번 창이 띄워지거나 일정이 동일한걸로 여러번 생성됨
- [x]  버튼, 텍스트필드, leading, trailing 수정 → SE, 16 pro